### PR TITLE
Add modifyUrl method

### DIFF
--- a/tests/modifyUrl.js
+++ b/tests/modifyUrl.js
@@ -1,0 +1,17 @@
+// wsHook loaded wsHook.js
+describe('Simple tests using the WebSocket object', function() {
+  var wsClient
+
+  describe('Modify Url', function() {
+    it('Modify the url', function(done) {
+        wsHook.modifyUrl = function(url) {
+          return 'wss://echo.websocket.org';
+        }
+        wsClient = new WebSocket('wss://echo2.websocket.org')
+        wsClient.onopen = function() {
+          expect(wsClient.url).to.equal('wss://echo.websocket.org/');
+          done();
+        }
+    })
+  })
+})

--- a/tests/test.html
+++ b/tests/test.html
@@ -15,6 +15,7 @@
   <script src="../wsHook.js"></script>
   <script src="before.js"></script>
   <script src="after.js"></script>
+  <script src="modifyUrl.js"></script>
   <script>
     mocha.checkLeaks();
     mocha.globals(['jQuery']);

--- a/wsHook.js
+++ b/wsHook.js
@@ -38,14 +38,19 @@ var wsHook = {};
   var after = wsHook.after = function (e, url) {
     return e
   }
+  var modifyUrl = wsHook.modifyUrl = function(url) {
+    return url
+  }
   wsHook.resetHooks = function () {
     wsHook.before = before
     wsHook.after = after
+    wsHook.modifyUrl = modifyUrl
   }
 
   var _WS = WebSocket
   WebSocket = function (url, protocols) {
     var WSObject
+    url = wsHook.modifyUrl(url) || url
     this.url = url
     this.protocols = protocols
     if (!this.protocols) { WSObject = new _WS(url) } else { WSObject = new _WS(url, protocols) }


### PR DESCRIPTION
Added the ability to modify the URL used to connect to the websocket before connection.

Example:
``` javascript
wsHook.modifyUrl = (url) => {
      // In this example we need to add the word socket to the url if it's not already there
      if (url.indexOf('socket') === -1) {
        // Replace the front of the URL with the socket url
        return url.replace(window.location.hostname, `wss://socket.${window.location.hostname}`);
      }
      return url;
    };
```